### PR TITLE
chore: grant web3-bot push access to go-ipfs-redirects

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -500,6 +500,8 @@ repositories:
         - lidel
       maintain:
         - justincjohnson
+      push:
+        - web3-bot
     description: IPFS HTTP Gateway _redirects file format parser
     teams:
       pull:


### PR DESCRIPTION
Granting web3-bot push access to go-ipfs-redirect so that we can enable Unified CI in that repository - https://github.com/protocol/.github/pull/357#pullrequestreview-1034375084