### PR TITLE
chore: remove go-ipfs-redirects

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -533,21 +533,6 @@ repositories:
         - thattommyhall
     default_branch: main
     visibility: public
-  go-ipfs-redirects:
-    collaborators:
-      admin:
-        - lidel
-      maintain:
-        - justincjohnson
-      push:
-        - web3-bot
-    default_branch: main
-    description: IPFS HTTP Gateway _redirects file format parser
-    teams:
-      pull:
-        - admin
-        - w3dt-stewards
-    visibility: public
   gomobile-ipfs:
     collaborators:
       admin:


### PR DESCRIPTION
It was moved to https://github.com/ipfs/go-ipfs-redirects-file (https://github.com/ipfs/github-mgmt/pull/58)