### PR TITLE
chore: add IPFS Ignite teammembers

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -40,6 +40,7 @@ members:
     - dharmapunk82
     - dignifiedquire
     - dirkmc
+    - djmcquillan
     - ericronne
     - flyingzumwalt
     - gfanton
@@ -78,11 +79,13 @@ members:
     - SgtPooki
     - stongo
     - thattommyhall
+    - tinytb
     - travisperson
     - vasco-santos
     - victorb
     - vmx
     - web3-bot
+    - whizzzkid
     - willscott
     - yusefnapora
 repositories:
@@ -2664,13 +2667,18 @@ teams:
         - autonome
         - lidel
         - olizilla
+        - SgtPooki
+        - tinytb
       member:
         - akrych
         - cwaring
+        - djmcquillan
         - ericronne
         - Gozala
         - hacdias
         - SgtPooki
+        - tinytb
+        - whizzzkid
     privacy: closed
   identity:
     description: Identity on IPFS

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2676,8 +2676,6 @@ teams:
         - ericronne
         - Gozala
         - hacdias
-        - SgtPooki
-        - tinytb
         - whizzzkid
     privacy: closed
   identity:


### PR DESCRIPTION
### Summary
Adding Dan, Nishant, and Elliot from the IPFS-Ignite (GUI & Tools) team to the ipfs-shipyard org and GUI team.

### Why do you need this?
I can't currently assign tasks or request reviews from these two. see https://github.com/ipfs-shipyard/pinning-service-compliance/pull/274#issuecomment-1401124617

### What else do we need to know?
Not much.

**DRI:** @SgtPooki
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
