### PR TITLE
Add laurentsenta to w3dt-stewards

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2888,5 +2888,6 @@ teams:
         - lidel
       member:
         - guseggert
+        - laurentsenta
         - SgtPooki
     privacy: closed


### PR DESCRIPTION
### Summary
Adding myself to w3dt-stewards

### Why do you need this?
I'm working on ipfs-check and would like team members' abilities, like assigning reviewers

### What else do we need to know?
none

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
