### PR TITLE
Add cewood as admin of shipyard

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -7,6 +7,7 @@ members:
     - andyschwab-admin
     - aschmahmann
     - BigLep
+    - cewood
     - daviddias
     - dchoi27
     - galargh
@@ -31,7 +32,6 @@ members:
     - AuHau
     - autonome
     - catiatpereira
-    - cewood
     - Codigo-Fuentes
     - coryschwartz
     - cwaring
@@ -4470,6 +4470,7 @@ teams:
       maintainer:
         - aschmahmann
         - BigLep
+        - cewood
         - lidel
       member:
         - guseggert


### PR DESCRIPTION
### Summary
Bump my access since we'll be using shipyard for more things re:nucleation.

### Why do you need this?
With nucleation we'll be using the ipfs-shipyard org for more things, so want to get proper access to help out and manage things going forward.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
