### PR TITLE
Reduce org owners/admins

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -9,35 +9,27 @@ members:
     - rvagg
     - Stebalien
   member:
-    - achingbrain
-    - alanshaw
-    - BigLep
-    - cewood
-    - daviddias
-    - dchoi27
-    - hsanjuan
-    - jacobheun
-    - jbenet
-    - Kubuxu
-    - marten-seemann
-    - momack2
-    - olizilla
-    - whyrusleeping
     - 0xDanomite
     - 2color
+    - achingbrain
     - aeddi
     - ajnavarro
     - akrych
+    - alanshaw
     - AliabbasMerchant
     - andyschwab
     - AuHau
     - autonome
+    - BigLep
     - catiatpereira
+    - cewood
     - Codigo-Fuentes
     - coryschwartz
     - cwaring
     - davidd8
     - daviddahl
+    - daviddias
+    - dchoi27
     - designsaves
     - dharmapunk82
     - dignifiedquire
@@ -51,10 +43,13 @@ members:
     - guseggert
     - haadcode
     - hacdias
+    - hsanjuan
     - hugomrdias
     - ianopolous
     - ipfsbot
     - ischasny
+    - jacobheun
+    - jbenet
     - jbenetsafer
     - jesseclay
     - jimpick
@@ -63,19 +58,23 @@ members:
     - Jorropo
     - KarolKozlowski
     - kasteph
+    - Kubuxu
     - laurentsenta
     - locotorp
     - lynnandtonic
     - magik6k
     - marcooliveira
+    - marten-seemann
     - masih
     - mcamou
     - mcollina
     - meiqimichelle
     - mishmosh
+    - momack2
     - moul
     - NeoTeo
     - ntninja
+    - olizilla
     - petar
     - ribasushi
     - seeni-dev
@@ -89,6 +88,7 @@ members:
     - vmx
     - web3-bot
     - whizzzkid
+    - whyrusleeping
     - willscott
     - yusefnapora
 repositories:

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2,27 +2,27 @@
 
 members:
   admin:
-    - achingbrain
-    - alanshaw
     - andyschwab-admin
     - aschmahmann
+    - galargh
+    - lidel
+    - rvagg
+    - Stebalien
+  member:
+    - achingbrain
+    - alanshaw
     - BigLep
     - cewood
     - daviddias
     - dchoi27
-    - galargh
     - hsanjuan
     - jacobheun
     - jbenet
     - Kubuxu
-    - lidel
     - marten-seemann
     - momack2
     - olizilla
-    - rvagg
-    - Stebalien
     - whyrusleeping
-  member:
     - 0xDanomite
     - 2color
     - aeddi


### PR DESCRIPTION
### Summary
This aligns with the "reduce org owners" step listed in https://github.com/ipfs/ipfs/issues/511.

This is the first step of wider 2024Q1 permissions cleanup.

### Why do you need this?
Github org safety.  See https://github.com/ipfs/ipfs/issues/511 for more info.

### Timeline
- [x] 2024-02-12: public PR
- [x] 2024-02-12: notify affected parties: https://github.com/ipfs-shipyard/github-mgmt/pull/71#issuecomment-1939246739
- [ ] 2024-02-14: merge this change assuming no major pushback

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request