### PR TITLE
chore: Add vesahc as a member

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2494,6 +2494,7 @@ repositories:
         - SgtPooki
         - tbenbow
         - willscott
+        - vesahc
     default_branch: main
     description: ipfs-þing-2023
     has_discussions: false

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -84,6 +84,7 @@ members:
     - tinytb
     - travisperson
     - vasco-santos
+    - vesahc
     - victorb
     - vmx
     - web3-bot
@@ -2494,7 +2495,6 @@ repositories:
         - SgtPooki
         - tbenbow
         - willscott
-        - vesahc
     default_branch: main
     description: ipfs-þing-2023
     has_discussions: false

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -84,7 +84,6 @@ members:
     - tinytb
     - travisperson
     - vasco-santos
-    - vesahc
     - victorb
     - vmx
     - web3-bot
@@ -2488,6 +2487,7 @@ repositories:
       admin:
         - autonome
         - cwaring
+        - vesahc
       push:
         - b5
         - bmann


### PR DESCRIPTION
### Summary
Trying to get added as an org member temporarily to complete Fleek migrations. 

### Why do you need this?
To complete Fleek migrations. Suspect if I'm added with member permissions I should be able to access the existing Fleek app install. 

### What else do we need to know?
Should only need access for around a week at most.

**DRI:** myself or @lidel

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
