### PR TITLE
Limiting team/repository access for users inactive for 60 months

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -532,6 +532,8 @@ repositories:
     archived: false
     collaborators:
       admin:
+        # KEEP: At the request from @lidel
+        - autonome
         - meandavejustice
       maintain:
         - yocontra
@@ -658,6 +660,8 @@ repositories:
     collaborators:
       admin:
         - orvn
+        # KEEP: At the request from @lidel
+        - mishmosh
     default_branch: main
     description: "Boilerplate ecosystem or hackathon project directory: see an
       example at https://ecosystem.ipfs.io"
@@ -4028,6 +4032,8 @@ repositories:
     archived: false
     collaborators:
       admin:
+        # KEEP: leading https://areweinterplanetaryyet.org
+        - autonome
         - ddimaria
         - John-LittleBearLabs
         - plauche

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -659,9 +659,9 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - orvn
         # KEEP: At the request from @lidel
         - mishmosh
+        - orvn
     default_branch: main
     description: "Boilerplate ecosystem or hackathon project directory: see an
       example at https://ecosystem.ipfs.io"

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -139,11 +139,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - andyschwab
-        - cwaring
-        - jdiogopeixoto
     default_branch: master
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -260,10 +255,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - alanshaw
-        - daviddias
     default_branch: master
     description: Create a page that can be embedded on a website that lists project
       contributors.
@@ -502,9 +493,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - RichardLitt
     default_branch: master
     description: Set the DNS records on Digital Ocean programmatically
     has_discussions: false
@@ -544,7 +532,6 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - autonome
         - meandavejustice
       maintain:
         - yocontra
@@ -576,7 +563,7 @@ repositories:
       .github/dependabot.yml:
         content: |
           version: 2
-          updates:            
+          updates:
           - package-ecosystem: "github-actions"
             directory: "/"
             schedule:
@@ -670,9 +657,7 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - mishmosh
         - orvn
-        - timelytree
     default_branch: main
     description: "Boilerplate ecosystem or hackathon project directory: see an
       example at https://ecosystem.ipfs.io"
@@ -751,9 +736,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - jimpick
     default_branch: master
     description: Landing page for experiments
     has_discussions: false
@@ -777,9 +759,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - RichardLitt
     default_branch: master
     description: Fetch and serve our users and contributors data from github
     has_discussions: false
@@ -858,8 +837,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - lidel
       push:
         - bjornleffler
         - web3-bot
@@ -884,11 +861,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - willscott
-      maintain:
-        - gammazero
     default_branch: main
     description: a datastore backed by a remote IPFS process over hte ipfs api
     has_discussions: false
@@ -930,7 +902,6 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - Gozala
         - lidel
       push:
         - joeltg
@@ -1009,11 +980,9 @@ repositories:
       push:
         - aeddi-sudo
         - asutula
-        - berty-assistant
         - carsonfarmer
         - jefft0
         - moul-bot
-        - moul-sudo
         - n0izn0iz
         - parkan
     default_branch: master
@@ -1051,9 +1020,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - hsanjuan
     default_branch: master
     description: Scripts for putting the Gutenberg project books on IPFS
     has_discussions: false
@@ -1127,7 +1093,6 @@ repositories:
     collaborators:
       admin:
         - aschmahmann
-        - ipfs-gui-bot
         - MarcoPolo
         - SgtPooki
     default_branch: main
@@ -1154,9 +1119,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - Stebalien
     default_branch: master
     description: Hubot plugin for pinning files to IPFS
     has_discussions: false
@@ -1237,8 +1199,6 @@ repositories:
       admin:
         - SgtPooki
         - whizzzkid
-      push:
-        - ipfs-gui-bot
     default_branch: main
     description: Metrics consent and client provider library for ipfs/ipfs-gui team
       (i.e. IPFS Ignite). See ipfs/ipfs-gui#129 for more details
@@ -1330,9 +1290,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - olizilla
     default_branch: master
     description: Drop a file to see it turn into blocks in your local blockstore
     has_discussions: false
@@ -1354,9 +1311,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - jnthnvctr
     default_branch: main
     description: The website for IPFS Camp 2022
     has_discussions: false
@@ -1439,7 +1393,6 @@ repositories:
       admin:
         - willscott
       push:
-        - petar
         - web3-bot
     default_branch: master
     description: A tool to scrape the ipfs network for information on the number of
@@ -1466,8 +1419,6 @@ repositories:
     collaborators:
       admin:
         - olizilla
-      maintain:
-        - juliaxbow
     default_branch: main
     description: The single-purpose css class names and font-face config to IPFS up your UI.
     has_discussions: false
@@ -1499,9 +1450,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - ipfsbot
     default_branch: master
     description: See how the DAGs get built
     has_discussions: false
@@ -1576,9 +1524,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      maintain:
-        - cewood
     default_branch: master
     description: " A circleci friendly Docker image for pinning things to cluster
       and updating dns"
@@ -1609,8 +1554,6 @@ repositories:
     archived: false
     collaborators:
       push:
-        - dignifiedquire
-        - krl
         - web3-bot
         - whizzzkid
     default_branch: main
@@ -1869,7 +1812,6 @@ repositories:
       push:
         - edgo914
         - flyingzumwalt
-        - RichardLitt
     default_branch: master
     description: A primer explaining IPFS and the Decentralized Web, viewable as a
       website, pdf or e-book
@@ -2030,9 +1972,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - haadcode
     default_branch: master
     description: IPFS Pubsub room
     has_discussions: false
@@ -2089,7 +2028,6 @@ repositories:
     collaborators:
       admin:
         - andyschwab
-        - jbenet
     default_branch: master
     description: Simple tarball encryption
     has_discussions: false
@@ -2233,12 +2171,8 @@ repositories:
       admin:
         - autonome
         - cwaring
-        - vesahc
       push:
-        - b5
-        - bmann
         - mishmosh
-        - SgtPooki
         - tbenbow
         - willscott
     default_branch: main
@@ -2267,9 +2201,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - BigLep
     default_branch: master
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -2805,8 +2736,6 @@ repositories:
         - Gozala
         - SgtPooki
         - whizzzkid
-      push:
-        - ipfs-gui-bot
     default_branch: main
     description: Implementation of in-memory IPFS Pinning Service API
     files:
@@ -2932,7 +2861,6 @@ repositories:
     collaborators:
       admin:
         - Arlodotexe
-        - guseggert
     default_branch: main
     files:
       .github/dependabot.yml:
@@ -2959,7 +2887,6 @@ repositories:
     collaborators:
       admin:
         - Arlodotexe
-        - guseggert
     default_branch: main
     description: InterPlanetary File System client for .Net (C#, VB, F# ...)
     files:
@@ -3129,9 +3056,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - achingbrain
     default_branch: master
     description: Like npm-registry-fetch, but uses IPFS to fetch dependencies
     has_discussions: false
@@ -3184,7 +3108,6 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - mishmosh
         - orvn
         - timelytree
       maintain:
@@ -3234,9 +3157,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - dignifiedquire
     default_branch: master
     description: Sharing scientific papers using ipfs
     has_discussions: false
@@ -3569,9 +3489,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - jimpick
     default_branch: master
     description: React components for Peer-* apps
     has_discussions: false
@@ -3700,10 +3617,6 @@ repositories:
     collaborators:
       push:
         - AfonsoVReis
-        - Areadrill
-        - nlfonseca
-        - Ricardo-Silva91
-        - ruimonteiro93
       triage:
         - vasa-develop
     default_branch: master
@@ -3734,13 +3647,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - parkan
-      push:
-        - jimpick
-        - momack2
-        - victorb
     default_branch: master
     description: PeerPad Discussion  Repo for Project Management and Design/UX Work
     has_discussions: false
@@ -3783,9 +3689,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - ntninja
     default_branch: master
     description: leveldb datastore implementation
     has_discussions: false
@@ -3957,8 +3860,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - hugomrdias
       maintain:
         - acostalima
     default_branch: master
@@ -4083,9 +3984,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      pull:
-        - Gozala
     default_branch: master
     description: Main entry repo for the IPFS Shipyard
     has_discussions: false
@@ -4130,7 +4028,6 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - autonome
         - ddimaria
         - John-LittleBearLabs
         - plauche
@@ -4203,9 +4100,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - daviddias
     default_branch: master
     description: Parse all the varints in a Buffer (for when there are varints everywhere)
     has_discussions: false
@@ -4259,7 +4153,6 @@ repositories:
       admin:
         - willscott
       maintain:
-        - davidd8
         - hannahhoward
         - masih
       push:
@@ -4446,10 +4339,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - jnthnvctr
-        - mishmosh
     default_branch: main
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -4471,17 +4360,37 @@ teams:
         - Stebalien
       member:
         - daviddias
-        - dignifiedquire
         - hacdias
         - hsanjuan
         - jbenet
-        - Kubuxu
         - mishmosh
         - olizilla
-        - vmx
         - whyrusleeping
     privacy: closed
   Alumni:
+    members:
+      member:
+        - ajnavarro
+        - akrych
+        - AuHau
+        - Codigo-Fuentes
+        - davidd8
+        - designsaves
+        - dharmapunk82
+        - dignifiedquire
+        - glouvigny
+        - ipfsbot
+        - jbenetsafer
+        - jesseclay
+        - jnthnvctr
+        - KarolKozlowski
+        - locotorp
+        - lynnandtonic
+        - marcooliveira
+        - mcollina
+        - petar
+        - stongo
+        - travisperson
     privacy: closed
   Berty:
     members:
@@ -4489,21 +4398,13 @@ teams:
         - aeddi
         - alanshaw
         - gfanton
-        - glouvigny
         - moul
     privacy: closed
   ci:
     description: ci
-    members:
-      member:
-        - ipfsbot
-        - locotorp
     privacy: closed
   cube:
     description: cube project
-    members:
-      member:
-        - hsanjuan
     privacy: closed
   github-mgmt stewards:
     # NOTE: created to capture users with push+ access to github-mgmt repository
@@ -4534,9 +4435,7 @@ teams:
         - olizilla
         - SgtPooki
       member:
-        - akrych
         - alanshaw
-        - cwaring
         - ericronne
         - Gozala
         - hacdias
@@ -4556,12 +4455,8 @@ teams:
   identity:
     description: Identity on IPFS
     members:
-      maintainer:
-        - aschmahmann
       member:
         - daviddahl
-        - dirkmc
-        - jimpick
     privacy: closed
   Infra:
     description: Protocol Labs Infrastructure Team
@@ -4569,7 +4464,6 @@ teams:
       member:
         - gmasgras
         - mcamou
-        - stongo
         - thattommyhall
     privacy: closed
   ipdx:
@@ -4599,29 +4493,16 @@ teams:
     description: People with write access to Javascript repositories
     members:
       maintainer:
-        - 2color
         - lidel
-        - rvagg
-        - sgtpooki
       member:
         - achingbrain
         - alanshaw
-        - AuHau
-        - daviddias
-        - dirkmc
         - Gozala
         - hacdias
         - hsanjuan
         - hugomrdias
-        - ipfsbot
         - jacobheun
         - jbenet
-        - magik6k
-        - momack2
-        - olizilla
-        - vasco-santos
-        - vmx
-        - yusefnapora
     privacy: closed
   Maintainers:
     description: People with Maintain access to all repositories
@@ -4645,18 +4526,8 @@ teams:
     privacy: closed
   peer-star:
     description: Peer Star Team
-    members:
-      member:
-        - akrych
-        - daviddias
-        - jimpick
     privacy: closed
   Performance and Benchmarking:
-    members:
-      maintainer:
-        - alanshaw
-      member:
-        - mcollina
     privacy: closed
   Pl Engres - DataSystems:
     members:
@@ -4664,23 +4535,17 @@ teams:
         - rvagg
         - willscott
       member:
-        - davidd8
         - ischasny
-        - jacobheun
         - masih
     privacy: closed
   primer:
     description: Team for updating ipfs-primer
-    members:
-      member:
-        - momack2
     privacy: closed
   Python:
     description: People with write access to Python repositories
     members:
       member:
         - AliabbasMerchant
-        - hsanjuan
         - kasteph
         - ntninja
         - seeni-dev
@@ -4690,39 +4555,26 @@ teams:
     members:
       member:
         - hsanjuan
-        - magik6k
     privacy: closed
   Swift:
     description: People with write access to Swift repositories
     members:
       member:
-        - hsanjuan
         - NeoTeo
     privacy: closed
   team-andyet:
-    members:
-      member:
-        - jacobheun
     privacy: secret
   team-moxy:
     members:
       member:
-        - hugomrdias
-        - marcooliveira
         - vasco-santos
     privacy: secret
   team-tableflip:
     members:
       member:
         - alanshaw
-        - daviddias
-        - olizilla
     privacy: secret
   Trigram:
-    members:
-      member:
-        - Codigo-Fuentes
-        - dchoi27
     privacy: closed
   w3dt-stewards:
     members:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
This PR cleans up user access by removing users who have been inactive for over 60 months (5 years) from teams and repositories.

A user is deemed inactive if they haven't performed any of the following actions in the past 60 months in a repository in question or in any of the repositories the team in question grants access to:
- created an issue or a pull request
- commented on an issue or a pull request
- reviewed a pull request
- commented on a commit
- pushed (in particular, force pushed) to a branch
- created a branch
- deleted a branch
- merged a pull request
- added a pull request to a merge queue

Any user who, after the introduction of the above changes, isn't a direct collaborator in any of the repositories and isn't a member of any teams is assigned to the `Alumni` team.

If a user's access to a repository or team should be restored, the appropriate line change should be reverted, and a comment starting with `KEEP: ` (followed by a reason) should be added directly above that line.

This pertains to the "'archive' inactive users and teams" in https://github.com/ipfs/ipfs/issues/511.

### Who is this targeting?

The current PR is what results from a [script to identify inactive users in an org](https://github.com/ipfs-shipyard/github-mgmt/blob/master/scripts/src/actions/remove-inactive-members.ts).

### Why is this being done?
See "Why do we care about periodically cleaning up permissions across the orgs?" in https://github.com/ipfs/ipfs/issues/511

### Is this set in stone?
No. This PR was created and being left open for some days to give awareness and incorporate feedback. We're not taking a "ask for permission" approach, as that would require way too much wrangling. Instead, we're giving visibility to what's proposed and inviting folks to comment and influence. A saving grace here is that none of this is a "one-way door". If something got messed up or missed, a follow-up PR can be done to correct it.

### Is anyone being removed from the organization?
No. All existing members of the org are staying members. In the most reduced/scoped-down case, someone will still be part of an "Alumni" team in the org to signal their past involvement. Thank you for your past contributions, and we certainly welcome you to play a more active role in the future.

### Timeline
2024-02-26: public PR
2024-03-04: notify affected parties with @mention: <insert LINK_TO_COMMENT_IN_THIS_PR>
2024-03-08: merge this change after incorporating feedback
2024-03-08: remove empty teams
