### PR TITLE
update w3dt-stewards group

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -4478,14 +4478,10 @@ teams:
     members:
       maintainer:
         - aschmahmann
-        - BigLep
         - lidel
       member:
+        - achingbrain
         - 2color
-        - galargh
-        - guseggert
         - hacdias
-        - Jorropo
-        - laurentsenta
         - SgtPooki
     privacy: closed

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -4480,8 +4480,8 @@ teams:
         - aschmahmann
         - lidel
       member:
-        - achingbrain
         - 2color
+        - achingbrain
         - hacdias
         - SgtPooki
     privacy: closed


### PR DESCRIPTION
### Summary
Updating the w3dt-stewards groups. While the group should probably be renamed, the group of people who should have permissions on the appropriate repos needed some updating.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
Updating permissions (mostly removals, one addition).

Notes on the changes:
- @laurentsenta @galargh: They have permissions where they need via the IPDX group
- @BigLep @guseggert @jorropo: They aren't operating in this group anymore, but happy to grant permissions if they need them to make like easier for any repos they contribute to
- @achingbrain seemed like an oversight that he wasn't in this group earlier given his involvement with some of the managed repos

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
