### PR TITLE
Cleanup GitHub-mgmt and Infra teams

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -4330,8 +4330,6 @@ teams:
         - cewood
         - lidel
       member:
-        - BigLep
-        - guseggert
         - willscott
     privacy: closed
   GUI:
@@ -4369,12 +4367,10 @@ teams:
         - daviddahl
     privacy: closed
   Infra:
-    description: Protocol Labs Infrastructure Team
+    description: Org Infrastructure
     members:
       member:
-        - gmasgras
-        - mcamou
-        - thattommyhall
+        - cewood
     privacy: closed
   ipdx:
     members:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
Cleaning up the GitHub-mgmt and Infra teams.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
Was noticing that there may be some extraneous permissions on repos and it seemed reasonable to clean them up:

- GitHub Mgmt
  - @BigLep @guseggert don't seem likely to be merging PRs here in the near future and they're sensitive. Although always welcome back 😄
- Infra
  - The Protocol Labs Infra doesn't manage anything in this group anymore (that's like the Interplanetary Shipyard Infra if anything). I've added @cewood as a placeholder/contact here, although my guess is that if it becomes necessary @ns4plabs will get added to the org and end up helping here).
  - @gmasgras @mcamou @thattommyhall are always welcome, and if there's some project you need permissions to help with  just comment or raise a PR

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

Nothing at the moment, I'm noticing there's a bunch of cleanup to be done but just taking it as I notice and have the time to file the PR.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
