### PR TITLE
update ipfsio-about permissions

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2175,7 +2175,7 @@ repositories:
     archived: false
     collaborators:
       maintain:
-         - gammazero
+        - gammazero
     default_branch: master
     has_discussions: false
     merge_commit_message: PR_TITLE

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2173,6 +2173,9 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
+    collaborators:
+      maintain:
+         - gammazero
     default_branch: master
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -2185,7 +2188,6 @@ repositories:
       admin:
         - admin
       maintain:
-        - gammazero
         - Infra
       push:
         - github-mgmt stewards

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2182,11 +2182,14 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
-      pull:
+      admin:
         - admin
-        - github-mgmt stewards
+      maintain:
         - Infra
+        - gammazero
+      push:
         - Maintainers
+        - github-mgmt stewards
     visibility: public
   ipfsx:
     advanced_security: false

--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2185,11 +2185,11 @@ repositories:
       admin:
         - admin
       maintain:
-        - Infra
         - gammazero
+        - Infra
       push:
-        - Maintainers
         - github-mgmt stewards
+        - Maintainers
     visibility: public
   ipfsx:
     advanced_security: false


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
Updating permissions on the ipfsio-about repo

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
- At the moment the people who are writing and have push access are doing so as org-wide admins rather than via repo permissions, this fixes that
- Promoted the Infra group to maintain access in case they need to modify settings for publishing
- Added @gammazero with maintainer access as well
- Groups that had pull access were given push since read is not a very useful permission in an open repo

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
