### PR TITLE
make achingbrain an org admin

### DIFF
--- a/github/ipfs-shipyard.yml
+++ b/github/ipfs-shipyard.yml
@@ -2,6 +2,7 @@
 
 members:
   admin:
+    - achingbrain
     - andyschwab-admin
     - aschmahmann
     - cewood
@@ -12,7 +13,6 @@ members:
   member:
     - 0xDanomite
     - 2color
-    - achingbrain
     - aeddi
     - ajnavarro
     - akrych


### PR DESCRIPTION
### Summary

Moves @achingbrain from `member` to `admin`.

### Why do you need this?

to assist with migrating useful repos away from this org, performing repo config tasks, reviewing and merging permissions related PRs and other day to day tasks.

### What else do we need to know?

Nothing

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
