### PR TITLE
feat: add web3-bot to all repos

### DIFF
--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 import {Repository} from '../resources/repository.js'
 import {runFormat} from './shared/format.js'
+import {runAddCollaboratorToAllRepos} from './shared/add-collaborator-to-all-repos.js'
 import {runSetPropertyInAllRepos} from './shared/set-property-in-all-repos.js'
 import {runToggleArchivedRepos} from './shared/toggle-archived-repos.js'
 import {runDescribeAccessChanges} from './shared/describe-access-changes.js'
@@ -21,6 +22,10 @@ async function run() {
     'secret_scanning_push_protection',
     true,
     r => isPublic(r)
+  )
+  await runAddCollaboratorToAllRepos(
+    'web3-bot',
+    Permission.Push
   )
   await runToggleArchivedRepos()
   const accessChangesDescription = await runDescribeAccessChanges()


### PR DESCRIPTION
This PR automates adding web3-bot to all the repositories in the organization. It has been internally configured to copy suspected AI and stale issue workflows to your repos it has access to. These would have been previously handled via github-mgmt but it was deemed inefficient.

This has already been tested in the [probe-lab organization](https://github.com/probe-lab/github-mgmt/pull/32).