### PR TITLE
fix: add missing import to the fix script

### DIFF
--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata'
+import {Permission} from '../resources/repository-collaborator.js'
 import {Repository} from '../resources/repository.js'
 import {runFormat} from './shared/format.js'
 import {runSetPropertyInAllRepos} from './shared/set-property-in-all-repos.js'


### PR DESCRIPTION
This adds a missing import to the fix script and actually applies the fix script to the configuration (manually).